### PR TITLE
Fix contributors API request

### DIFF
--- a/src/pages/contributors.jsx
+++ b/src/pages/contributors.jsx
@@ -88,9 +88,9 @@ export default compose(
   withState('contributors', 'setContributors'),
   lifecycle({
     componentDidMount() {
-      fetch('https://api.github.com/repos/kitos/web-purple/contributors')
+      fetch('https://api.github.com/repos/WebPurple/site/contributors')
         .then(r => r.json())
-        .then(contributors => this.props.setContributors(contributors))
+        .then(contributors => this.props.setContributors(Array.isArray(contributors) ? contributors : []))
     },
   }),
 )(ContributorsPage)

--- a/src/pages/contributors.jsx
+++ b/src/pages/contributors.jsx
@@ -90,7 +90,11 @@ export default compose(
     componentDidMount() {
       fetch('https://api.github.com/repos/WebPurple/site/contributors')
         .then(r => r.json())
-        .then(contributors => this.props.setContributors(Array.isArray(contributors) ? contributors : []))
+        .then(contributors =>
+          this.props.setContributors(
+            Array.isArray(contributors) ? contributors : [],
+          ),
+        )
     },
   }),
 )(ContributorsPage)


### PR DESCRIPTION
Issue: #271.

* Fixed request url;
* Implemented error handling.

So that the GitHub doesn't block frequent requests, requests must be sent using [provider](https://github.com/WebPurple/provider) in the future versions.