### PR TITLE
Sort blog posts by date field

### DIFF
--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -45,7 +45,7 @@ export default mapProps(({ data: { allMarkdownRemark: { edges } } }) => ({
 
 export let pageQuery = graphql`
   query AllPosts {
-    allMarkdownRemark {
+    allMarkdownRemark(sort: { fields: frontmatter___date, order: DESC }) {
       edges {
         node {
           id


### PR DESCRIPTION
Right now, I'm in process of writing a new blog post, and notice that blogs post has no sorting based on date. Imho, blog should be sorted from latest to oldest. 

Found a way to implement sorting in graphql query, but there is a possibility to also sort dates in mapProps HOC. Found 1st option to be more elegant